### PR TITLE
Updates to latest wazero and wasmtime

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/second-state/WasmEdge-go v0.9.2
 	github.com/sirupsen/logrus v1.8.1
 	github.com/stretchr/testify v1.7.1
-	github.com/tetratelabs/wazero v0.0.0-20220509065650-96bc7c84624e
+	github.com/tetratelabs/wazero v0.0.0-20220510030018-8dd797e108db
 	github.com/wasmerio/wasmer-go v1.0.4
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 )

--- a/go.mod
+++ b/go.mod
@@ -3,12 +3,12 @@ module github.com/wuhuizuo/go-wasm-go
 go 1.17
 
 require (
-	github.com/bytecodealliance/wasmtime-go v0.35.0
+	github.com/bytecodealliance/wasmtime-go v0.36.0
 	github.com/dop251/goja v0.0.0-20220331101355-451b4e4cab3d
 	github.com/second-state/WasmEdge-go v0.9.2
 	github.com/sirupsen/logrus v1.8.1
 	github.com/stretchr/testify v1.7.1
-	github.com/tetratelabs/wazero v0.0.0-20220419085257-45ccab589bc8
+	github.com/tetratelabs/wazero v0.0.0-20220509065650-96bc7c84624e
 	github.com/wasmerio/wasmer-go v1.0.4
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/bytecodealliance/wasmtime-go v0.35.0 h1:VZjaZ0XOY0qp9TQfh0CQj9zl/AbdeXePVTALy8V1sKs=
-github.com/bytecodealliance/wasmtime-go v0.35.0/go.mod h1:q320gUxqyI8yB+ZqRuaJOEnGkAnHh6WtJjMaT2CW4wI=
+github.com/bytecodealliance/wasmtime-go v0.36.0 h1:B6thr7RMM9xQmouBtUqm1RpkJjuLS37m6nxX+iwsQSc=
+github.com/bytecodealliance/wasmtime-go v0.36.0/go.mod h1:q320gUxqyI8yB+ZqRuaJOEnGkAnHh6WtJjMaT2CW4wI=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -28,8 +28,8 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMTY=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/tetratelabs/wazero v0.0.0-20220419085257-45ccab589bc8 h1:8DehcP+bZ/uUAR+ssNpIy3sZW3KKTL6V3KYANwXG2E4=
-github.com/tetratelabs/wazero v0.0.0-20220419085257-45ccab589bc8/go.mod h1:Y4X/zO4sC2dJjZG9GDYNRbJGogfqFYJY/BbyKlOxXGI=
+github.com/tetratelabs/wazero v0.0.0-20220509065650-96bc7c84624e h1:ZITQpzJuxUcDmy1c1MxU3XMO2SH3j9J0d7F9gyrySJs=
+github.com/tetratelabs/wazero v0.0.0-20220509065650-96bc7c84624e/go.mod h1:Y4X/zO4sC2dJjZG9GDYNRbJGogfqFYJY/BbyKlOxXGI=
 github.com/wasmerio/wasmer-go v1.0.4 h1:MnqHoOGfiQ8MMq2RF6wyCeebKOe84G88h5yv+vmxJgs=
 github.com/wasmerio/wasmer-go v1.0.4/go.mod h1:0gzVdSfg6pysA6QVp6iVRPTagC6Wq9pOE8J86WKb2Fk=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c h1:5KslGYwFpkhGh+Q16bwMP3cOontH8FOep7tGV86Y7SQ=

--- a/go.sum
+++ b/go.sum
@@ -28,8 +28,8 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMTY=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/tetratelabs/wazero v0.0.0-20220509065650-96bc7c84624e h1:ZITQpzJuxUcDmy1c1MxU3XMO2SH3j9J0d7F9gyrySJs=
-github.com/tetratelabs/wazero v0.0.0-20220509065650-96bc7c84624e/go.mod h1:Y4X/zO4sC2dJjZG9GDYNRbJGogfqFYJY/BbyKlOxXGI=
+github.com/tetratelabs/wazero v0.0.0-20220510030018-8dd797e108db h1:HQDOsOFGBdhO6c163iIT0NEod1uenfxTLJWkaUTD42k=
+github.com/tetratelabs/wazero v0.0.0-20220510030018-8dd797e108db/go.mod h1:Y4X/zO4sC2dJjZG9GDYNRbJGogfqFYJY/BbyKlOxXGI=
 github.com/wasmerio/wasmer-go v1.0.4 h1:MnqHoOGfiQ8MMq2RF6wyCeebKOe84G88h5yv+vmxJgs=
 github.com/wasmerio/wasmer-go v1.0.4/go.mod h1:0gzVdSfg6pysA6QVp6iVRPTagC6Wq9pOE8J86WKb2Fk=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c h1:5KslGYwFpkhGh+Q16bwMP3cOontH8FOep7tGV86Y7SQ=

--- a/runner/wasm/wasmtime/wasmtime_go.go
+++ b/runner/wasm/wasmtime/wasmtime_go.go
@@ -35,8 +35,7 @@ func newWasmInstance(store *wasmtime.Store, file string) *wasmtime.Instance {
 
 func newWasmStore() *wasmtime.Store {
 	config := wasmtime.NewConfig()
-	config.SetWasmModuleLinking(true)
-	// config.SetInterruptable(true)
+	// config.SetEpochInterruption(true)
 	// config.SetConsumeFuel(true)
 	// config.SetDebugInfo(true)
 

--- a/runner/wasm/wasmtime/wasmtime_tinygo.go
+++ b/runner/wasm/wasmtime/wasmtime_tinygo.go
@@ -36,7 +36,6 @@ func newWasiInstance(store *wasmtime.Store, file string) *wasmtime.Instance {
 
 func newWasiStore() *wasmtime.Store {
 	config := wasmtime.NewConfig()
-	config.SetInterruptable(true)
 	config.SetWasmReferenceTypes(true)
 	config.SetWasmThreads(true)
 	config.SetWasmBulkMemory(true)

--- a/runner/wasm/wasmtime/x.go
+++ b/runner/wasm/wasmtime/x.go
@@ -27,16 +27,6 @@ func TransInBytesParam(store *wasmtime.Store, instance *wasmtime.Instance, in []
 	return aret, size, size
 }
 
-func TransOutBytesReturn(store *wasmtime.Store, instance *wasmtime.Instance, cap int32) (_, _, _ interface{}) {
-	// malloc memory space.
-	calloc := instance.GetFunc(store, "malloc")
-	aret, _ := calloc.Call(store, cap)
-
-	store.InterruptHandle()
-
-	return aret, int32(0), cap
-}
-
 func ReadOutBytesReturn(store *wasmtime.Store, instance *wasmtime.Instance, ptr, size int32) []byte {
 	return instance.GetExport(store, "memory").Memory().UnsafeData(store)[ptr : ptr+size]
 }

--- a/runner/wasm/wazero/wazero_go.go
+++ b/runner/wasm/wazero/wazero_go.go
@@ -14,7 +14,7 @@ import (
 func NewGoWASMStoreWithWazero(b testing.TB, wasmFile string) (api.Module, func() error) {
 	ctx := context.Background()
 
-	binary, err := os.ReadFile(wasmFile)
+	source, err := os.ReadFile(wasmFile)
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -26,22 +26,26 @@ func NewGoWASMStoreWithWazero(b testing.TB, wasmFile string) (api.Module, func()
 		b.Fatal(err)
 	}
 
-	code, err := runtime.CompileModule(ctx, binary)
+	compiled, err := runtime.CompileModule(ctx, source, wazero.NewCompileConfig())
 	if err != nil {
-		host.Close()
+		_ = host.Close(ctx)
 		b.Fatal(err)
 	}
 
 	config := wazero.NewModuleConfig().WithName(wazeroModName)
-	module, err := runtime.InstantiateModuleWithConfig(ctx, code, config)
+	module, err := runtime.InstantiateModule(ctx, compiled, config)
 	if err != nil {
-		host.Close()
+		_ = host.Close(ctx)
 		b.Fatal(err)
 	}
 
 	return module, func() (err error) {
-		module.Close()
-		host.Close()
+		if e := module.Close(ctx); e != nil {
+			err = e
+		}
+		if e := host.Close(ctx); e != nil && err != nil {
+			err = e
+		}
 		return
 	}
 }
@@ -65,10 +69,10 @@ func CallGoWASMFuncWithWazero(t testing.TB, module api.Module, funcName string, 
 func instantiateHostModuleForGo(ctx context.Context, runtime wazero.Runtime) (api.Module, error) {
 	return runtime.NewModuleBuilder("go").
 		ExportFunctions(map[string]interface{}{
-			"debug":                         func(sp int32) { fmt.Println(sp) },
-			"runtime.resetMemoryDataView":   func(int32) {},
-			"runtime.wasmExit":              func(m api.Module, code uint32) {
-				_ = m.CloseWithExitCode(code)
+			"debug":                       func(sp int32) { fmt.Println(sp) },
+			"runtime.resetMemoryDataView": func(int32) {},
+			"runtime.wasmExit": func(ctx context.Context, m api.Module, code uint32) {
+				_ = m.CloseWithExitCode(ctx, code)
 			},
 			"runtime.wasmWrite":             func(int32) {},
 			"runtime.nanotime1":             func(int32) {},


### PR DESCRIPTION
This removes interrupt handling as it changed so much in implementation
that it needs to be recreated.